### PR TITLE
deprecated since 2.0.13

### DIFF
--- a/helpers/MysqlBackup.php
+++ b/helpers/MysqlBackup.php
@@ -2,11 +2,11 @@
 
 namespace spanjeta\modules\backup\helpers;
 
-use yii\base\Object;
+use yii\base\BaseObject;
 use Yii;
 use yii\db\Exception;
 
-class MysqlBackup extends Object {
+class MysqlBackup extends BaseObject {
 	public $tables = [ ];
 	public $fp;
 	public $file_name;


### PR DESCRIPTION
deprecated since 2.0.13, the class name `Object` is invalid since PHP 7.2, use [[BaseObject]] instead.