### PR TITLE
Set minimal Yii2 version for this package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "yiisoft/yii2": "*"
+        "yiisoft/yii2": "~2.0.13"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
`\yii\base\BaseObject` has been implemented only in `2.0.13` Yii2 release. Also, when Yii2 release their `2.1.0` version, this plugin will become incompatible with it, so version lock on `2.0.*` branch is needed anyway.